### PR TITLE
Add HumBLE Explorer to third-party-applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Textualize is responsible for creating frameworks / projects like:
 - [Rich Pixels](https://github.com/darrenburns/rich-pixels) - A Rich-compatible library for writing pixel images and ASCII art to the terminal.
 - [Astview](https://github.com/davep/textual-astview) - A Textual-based Python AST viewing widget library and application.
 - [FivePyFive](https://github.com/davep/fivepyfive) - An annoying puzzle for the terminal; built with Textual.
+- [HumBLE Explorer](https://github.com/koenvervloesem/humble-explorer) - A cross-platform, command-line and human-friendly Bluetooth Low Energy Scanner built with Textual.
 
 ## Tutorials
 


### PR DESCRIPTION
This adds my project HumBLE Explorer, a Bluetooth Low Energy scanner built with Textual, to the list of third-party applications.