### PR TITLE
Add dialecticus to Third Party Applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Textualize is responsible for creating frameworks / projects like:
 - [Conways Game of Life](https://github.com/thomascrha/textual-game-of-life) -  A implementation of Conway's game of life (cellular automata) in the terminal using textual.
 - [Django-TUI](https://github.com/anze3db/django-tui) - Inspect and run Django Commands in a text-based user interface (TUI).
 - [Rexi](https://github.com/royreznik/rexi) - Terminal UI for Regex Testing.
+- [dialecticus](https://github.com/oudeis01/dialecticus) - Watch two language models debate with evidence-grounded citations in your terminal.
 
 
 ## Tutorials


### PR DESCRIPTION
### Add dialecticus to Third Party Applications

**[dialecticus](https://github.com/oudeis01/dialecticus)** is a Python TUI application built with Textual that lets you watch two language models debate a topic, with every claim cited back to a read-only file corpus.

**Why it fits this list:**
- Built entirely with Textual for the terminal interface
- Full TUI with step mode, pause/resume, moderator injection, and thinking toggle
- Real-world demonstration of Textual's reactive widgets, screens, and CSS styling
- Ships with self-contained demos that work on free models

**Link:** https://github.com/oudeis01/dialecticus